### PR TITLE
change repo name for release build call

### DIFF
--- a/cmd/gitalchemist/Makefile
+++ b/cmd/gitalchemist/Makefile
@@ -117,7 +117,7 @@ mac:
 
 RELEASENAME=$(BINARYNAME)-$(REL)
 GIT_HOST=github.com
-REPOPATH=https://github.com/HMS-Analytical-Software/czemmel-goGitAlchemist
+REPOPATH=https://github.com/HMS-Analytical-Software/goGitAlchemist
 
 release:
 ifeq ($(strip $(REL)),)


### PR DESCRIPTION
This PR contains the following changes:

- The target for the github release creation was adjusted to the new repo name