### PR TITLE
Run unit tests as part of PR and report tests to github

### DIFF
--- a/.github/workflows/go-unit-test.yml
+++ b/.github/workflows/go-unit-test.yml
@@ -43,3 +43,4 @@ jobs:
       with:
         name: Test Results (${{ matrix.os }})
         path: report.json
+        reporter: golang-json


### PR DESCRIPTION
This PR updates the unit-test workflow such that it gets executed when a PR is created. Additionally, the test results are reported back to github using the [dorny test reporter ](https://github.com/dorny/test-reporter) action.