### PR TITLE
Feature/jc/adjust module name to repo name

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -131,9 +131,9 @@ or acceptance tests.
     go vet -lostcancel=false ./...
     golangci-lint run
     go test ./...
-    ok      github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/cmd/gitalchemist      0.003s
-    ok      github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist 0.021s
-    ok      github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/check     0.003s
+    ok      github.com/HMS-Analytical-Software/goGitAlchemist/cmd/gitalchemist      0.003s
+    ok      github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist 0.021s
+    ok      github.com/HMS-Analytical-Software/goGitAlchemist/pkg/check     0.003s
 
 # github workflows
 
@@ -195,19 +195,19 @@ If you append "?m=all" to the url, also unexported elements are shown.
 
 ## Example: start page
 
-http://localhost:6060/pkg/github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/
+http://localhost:6060/pkg/github.com/HMS-Analytical-Software/goGitAlchemist/
 
 ![doc/images/example\_godoc\_mainpage.png](doc/images/example_godoc_mainpage.png)
 
 ## Example: exported only
 
-http://localhost:6060/pkg/github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/
+http://localhost:6060/pkg/github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/
 
 ![doc/images/example\_godoc\_exported.png](doc/images/example_godoc_exported.png)
 
 ## Example: with unexported
 
-http://localhost:6060/pkg/github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/?m=all
+http://localhost:6060/pkg/github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/?m=all
 
 ![doc/images/example\_godoc\_unexported.png](doc/images/example_godoc_unexported.png)
 
@@ -230,8 +230,8 @@ The information can be displayed by calling go version.
 
     cmd/gitalchemist> go version -m gitalchemist
     gitalchemist: go1.24.0
-            path    github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/cmd/gitalchemist
-            mod     github.com/HMS-Analytical-Software/czemmel-goGitAlchemist       v0.1.3-0.20250301162826-66028cd15f55
+            path    github.com/HMS-Analytical-Software/goGitAlchemist/cmd/gitalchemist
+            mod     github.com/HMS-Analytical-Software/goGitAlchemist       v0.1.3-0.20250301162826-66028cd15f55
             dep     gopkg.in/yaml.v3        v3.0.1  h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
             build   -buildmode=exe
             build   -compiler=gc
@@ -275,7 +275,7 @@ Example:
 
 Example:
 
-    module github.com/HMS-Analytical-Software/czemmel-goGitAlchemist
+    module github.com/HMS-Analytical-Software/goGitAlchemist
 
     go 1.24.0
 

--- a/Makefile
+++ b/Makefile
@@ -40,5 +40,5 @@ lint:
 # browser
 docserver:
 	godoc &
-	xdg-open http://localhost:6060/pkg/github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/
+	xdg-open http://localhost:6060/pkg/github.com/HMS-Analytical-Software/goGitAlchemist/
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ cmd/gitalchemist> ./gitalchemist -verbose -cfgdir testdata basic_workflow
 2025/02/23 10:37:16 [DEBUG] makedir "cwd/remotes/basic_workflow"
 2025/02/23 10:37:16 [INFO] 1/4: init --bare --initial-branch=main .
 2025/02/23 10:37:16 [DEBUG] "cwd/remotes/basic_workflow": git []string{"init", "--bare", "--initial-branch=main", "."}
-2025/02/23 10:37:16 [DEBUG] Initialized empty Git repository in /home/jochen/work/hms/czemmel-goGitAlchemist/cmd/gitalchemist/cwd/remotes/basic_workflow/
+2025/02/23 10:37:16 [DEBUG] Initialized empty Git repository in /home/jochen/work/hms/goGitAlchemist/cmd/gitalchemist/cwd/remotes/basic_workflow/
 2025/02/23 10:37:16 [INFO] 1/4: clone remotes/basic_workflow basic_workflow
 2025/02/23 10:37:16 [DEBUG] "cwd": git []string{"clone", "remotes/basic_workflow", "basic_workflow"}
 2025/02/23 10:37:16 [DEBUG] Cloning into 'basic_workflow'...

--- a/cmd/gitalchemist/README.md
+++ b/cmd/gitalchemist/README.md
@@ -88,7 +88,7 @@ Example: run test for default TASK "basic\_workflow" in verbose mode:
     --- PASS: TestAcceptance (0.16s)
         --- PASS: TestAcceptance/basic_workflow (0.04s)
     PASS
-    ok      github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/cmd/gitalchemist      0.158s
+    ok      github.com/HMS-Analytical-Software/goGitAlchemist/cmd/gitalchemist      0.158s
 
 # acceptance tests in github
 

--- a/cmd/gitalchemist/acc_test.go
+++ b/cmd/gitalchemist/acc_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/check"
+	"github.com/HMS-Analytical-Software/goGitAlchemist/pkg/check"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/cmd/gitalchemist/main.go
+++ b/cmd/gitalchemist/main.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist"
+	"github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist"
 )
 
 func main() {

--- a/cmd/gitalchemist/options_test.go
+++ b/cmd/gitalchemist/options_test.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/check"
+	"github.com/HMS-Analytical-Software/goGitAlchemist/pkg/check"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/cmd/gitalchemist/run_test.go
+++ b/cmd/gitalchemist/run_test.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist"
-	"github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/check"
+	"github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist"
+	"github.com/HMS-Analytical-Software/goGitAlchemist/pkg/check"
 )
 
 const testDataDir = "testdata"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/HMS-Analytical-Software/czemmel-goGitAlchemist
+module github.com/HMS-Analytical-Software/goGitAlchemist
 
 go 1.24.0
 

--- a/pkg/alchemist/README.md
+++ b/pkg/alchemist/README.md
@@ -204,7 +204,7 @@ Example: run all unit tests
     go test
     ok
     PASS
-    ok      github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist 0.023s
+    ok      github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist 0.023s
 
 Example: run a specific subtest in verbose mode:
 
@@ -216,7 +216,7 @@ Example: run a specific subtest in verbose mode:
     --- PASS: TestListBookContent (0.00s)
         --- SKIP: TestListBookContent/dir_not_found (0.00s)
     PASS
-    ok      github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist 0.003s
+    ok      github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist 0.003s
 
 
 ## test coverage
@@ -227,58 +227,58 @@ Example: examine code coverage
 	ok
 	PASS
 	coverage: 98.2% of statements
-	ok  	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist	0.027s
+	ok  	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist	0.027s
 	go tool cover -func=cover.txt
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/adept.go:25:			newAdept	100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/adept.go:34:			git		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/adept.go:56:			makedir		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/adept.go:68:			copy		85.7%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/adept.go:115:			copyFile	100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/adept.go:166:			examine		94.4%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/adept.go:204:			examineTarget	90.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/book.go:16:			ListPages	100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/book.go:39:			ListBookContent	90.9%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/error.go:9:			Error		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/error.go:19:			Error		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/error.go:31:			Error		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/error.go:36:			Unwrap		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/error.go:51:			Error		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/error.go:67:			Unwrap		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/error.go:81:			Error		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/error.go:86:			Unwrap		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/formula.go:20:			Transmute	100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/formula.go:74:			UnmarshalYAML	100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/formula.go:132:			unmarshalCaster	100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/formula.go:145:			Read		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/formula.go:157:			readFormula	100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/laboratory.go:26:		getAuthor	100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/logger.go:12:			debug		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/logger.go:24:			info		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/novice.go:18:			newNovice	100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/novice.go:29:			git		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/novice.go:36:			copy		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/novice.go:43:			makedir		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/spelladd.go:11:			validate	100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/spelladd.go:19:			cast		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/spellcommit.go:12:		validate	100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/spellcommit.go:25:		cast		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/spellcreateaddcommit.go:19:	validate	100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/spellcreateaddcommit.go:48:	cast		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/spellcreatefile.go:14:		validate	100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/spellcreatefile.go:25:		cast		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/spellgit.go:14:			validate	100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/spellgit.go:22:			cast		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/spellgit.go:38:			splitArgs	100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/spellinitrepo.go:15:		validate	100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/spellinitrepo.go:26:		cast		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/spellmerge.go:16:		validate	100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/spellmerge.go:27:		cast		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/spellmove.go:14:		validate	100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/spellmove.go:25:		cast		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/spellpush.go:11:		validate	100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/spellpush.go:16:		cast		100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/spellremoveandcommit.go:17:	validate	100.0%
-	github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist/spellremoveandcommit.go:32:	cast		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/adept.go:25:			newAdept	100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/adept.go:34:			git		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/adept.go:56:			makedir		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/adept.go:68:			copy		85.7%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/adept.go:115:			copyFile	100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/adept.go:166:			examine		94.4%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/adept.go:204:			examineTarget	90.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/book.go:16:			ListPages	100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/book.go:39:			ListBookContent	90.9%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/error.go:9:			Error		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/error.go:19:			Error		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/error.go:31:			Error		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/error.go:36:			Unwrap		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/error.go:51:			Error		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/error.go:67:			Unwrap		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/error.go:81:			Error		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/error.go:86:			Unwrap		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/formula.go:20:			Transmute	100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/formula.go:74:			UnmarshalYAML	100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/formula.go:132:			unmarshalCaster	100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/formula.go:145:			Read		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/formula.go:157:			readFormula	100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/laboratory.go:26:		getAuthor	100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/logger.go:12:			debug		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/logger.go:24:			info		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/novice.go:18:			newNovice	100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/novice.go:29:			git		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/novice.go:36:			copy		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/novice.go:43:			makedir		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/spelladd.go:11:			validate	100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/spelladd.go:19:			cast		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/spellcommit.go:12:		validate	100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/spellcommit.go:25:		cast		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/spellcreateaddcommit.go:19:	validate	100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/spellcreateaddcommit.go:48:	cast		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/spellcreatefile.go:14:		validate	100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/spellcreatefile.go:25:		cast		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/spellgit.go:14:			validate	100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/spellgit.go:22:			cast		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/spellgit.go:38:			splitArgs	100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/spellinitrepo.go:15:		validate	100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/spellinitrepo.go:26:		cast		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/spellmerge.go:16:		validate	100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/spellmerge.go:27:		cast		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/spellmove.go:14:		validate	100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/spellmove.go:25:		cast		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/spellpush.go:11:		validate	100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/spellpush.go:16:		cast		100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/spellremoveandcommit.go:17:	validate	100.0%
+	github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist/spellremoveandcommit.go:32:	cast		100.0%
 	total:													(statements)	98.2%
 	go tool cover -html=cover.txt -o cover.html
 	echo "chromium-browser cover.html &"
@@ -347,10 +347,10 @@ Example:
     --- PASS: TestDockerAdeptFileCopy (0.00s)
         --- SKIP: TestDockerAdeptFileCopy/copy_target_not_writeable (0.00s)
     PASS
-    ok      github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist 0.004s
+    ok      github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist 0.004s
     --- PASS: TestStartDocker (8.70s)
     PASS
-    ok      github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist 8.702s
+    ok      github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist 8.702s
 
 To examine the conainer, just execute the docker exec command that is displayed
 in the test output:

--- a/pkg/alchemist/adept_test.go
+++ b/pkg/alchemist/adept_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/check"
+	"github.com/HMS-Analytical-Software/goGitAlchemist/pkg/check"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )

--- a/pkg/alchemist/adeptgit_test.go
+++ b/pkg/alchemist/adeptgit_test.go
@@ -9,7 +9,7 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/check"
+	"github.com/HMS-Analytical-Software/goGitAlchemist/pkg/check"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )

--- a/pkg/alchemist/book_test.go
+++ b/pkg/alchemist/book_test.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/alchemist"
-	"github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/check"
+	"github.com/HMS-Analytical-Software/goGitAlchemist/pkg/alchemist"
+	"github.com/HMS-Analytical-Software/goGitAlchemist/pkg/check"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )

--- a/pkg/alchemist/formula_test.go
+++ b/pkg/alchemist/formula_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/check"
+	"github.com/HMS-Analytical-Software/goGitAlchemist/pkg/check"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )

--- a/pkg/alchemist/spell_test.go
+++ b/pkg/alchemist/spell_test.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/check"
+	"github.com/HMS-Analytical-Software/goGitAlchemist/pkg/check"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/pkg/check/error_test.go
+++ b/pkg/check/error_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/HMS-Analytical-Software/czemmel-goGitAlchemist/pkg/check"
+	"github.com/HMS-Analytical-Software/goGitAlchemist/pkg/check"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 


### PR DESCRIPTION
This PR contains the following changes:

adjust the module name to the repository name in 

- go.mod
- the go files and
- the documentation.

It resolves #8 